### PR TITLE
Expose sensor units, box name and infer schema capabilites

### DIFF
--- a/src/gateway-addon.d.ts
+++ b/src/gateway-addon.d.ts
@@ -4,6 +4,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+interface Link {
+    rel: string;
+    mediaType: string;
+    href: string;
+}
+
 declare module 'gateway-addon' {
     class Property {
         constructor(device: Device, name: string, propertyDescr: {});
@@ -12,8 +18,10 @@ declare module 'gateway-addon' {
 
     class Device {
         protected '@context': string;
+        protected '@type': string[];
         protected name: string;
         protected description: string;
+        protected links: Link[];
 
         constructor(adapter: Adapter, id: string);
 

--- a/src/gateway-addon.d.ts
+++ b/src/gateway-addon.d.ts
@@ -14,6 +14,7 @@ declare module 'gateway-addon' {
     class Property {
         constructor(device: Device, name: string, propertyDescr: {});
         public setCachedValue(value: any): void;
+        public setCachedValueAndNotify(value: any): boolean;
     }
 
     class Device {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,6 @@
 
 'use strict';
 
-import { GoogleHomeAdapter } from './opensensemap-adapter';
+import { OpenSenseMapAdapter } from './opensensemap-adapter';
 
-export = (addonManager: any, manifest: any) => new GoogleHomeAdapter(addonManager, manifest);
+export = (addonManager: any, manifest: any) => new OpenSenseMapAdapter(addonManager, manifest);

--- a/src/opensensemap-adapter.ts
+++ b/src/opensensemap-adapter.ts
@@ -114,8 +114,8 @@ class OpenSenseBox extends Device {
 
       if (property) {
         if (sensor.lastMeasurement && sensor.lastMeasurement.value) {
-          property.setCachedValue(sensor.lastMeasurement.value);
-          this.notifyPropertyChanged(property);
+          const numberValue = Number.parseFloat(sensor.lastMeasurement.value);
+          property.setCachedValueAndNotify(numberValue);
         }
       } else {
         console.warn(`Could not find property for sensor ${id}`);

--- a/src/opensensemap-adapter.ts
+++ b/src/opensensemap-adapter.ts
@@ -16,10 +16,12 @@ interface Sensor {
   _id: string;
   lastMeasurement: LastMeasurement;
   title: string;
+  unit: string;
 }
 
 interface SenseBox {
   _id: string;
+  name: string;
   sensors: Sensor[];
 }
 
@@ -27,28 +29,75 @@ interface Config {
   boxIds: string[]
 }
 
+const SCHEMA_UNITS: { [key: string]: string } = {
+  '°C': 'degree celsius',
+  '%': 'percent',
+  'µg/m³': 'micrograms per cubic metre',
+  'hPa': 'hectopascal',
+  'V': 'volt'
+};
+
+const PROPERTY_TYPE_BY_UNIT: { [key: string]: string } = {
+  '°C': 'TemperatureProperty',
+  'µg/m³': 'DensityProperty',
+  'hPa': 'BarometricPressureProperty',
+  'V': 'VoltageProperty'
+};
+
+const DEVICE_CAPABILITIES: { [key: string]: string } = {
+  TemperatureProperty: 'TemperatureSensor',
+  BarometricPressureProperty: 'BarometricPressureSensor'
+};
+
 class OpenSenseBox extends Device {
   constructor(adapter: any, manifest: any, private boxId: string) {
     super(adapter, `opensensebox-${boxId}`);
     this['@context'] = 'https://iot.mozilla.org/schemas/';
     this.name = `${OpenSenseBox.name} (${boxId})`;
     this.description = manifest.description;
+    this.links = [
+      {
+        rel: 'alternate',
+        mediaType: 'text/html',
+        href: `https://opensensemap.org/explore/${boxId}`
+      }
+    ];
   }
 
   async init() {
     const senseBox = await this.getData();
+    const deviceCapabilities: string[] = [];
 
     for (const sensor of senseBox.sensors) {
       const id = sensor._id;
+      let unit = sensor.unit;
+      if (SCHEMA_UNITS.hasOwnProperty(unit)) {
+        unit = SCHEMA_UNITS[unit];
+      }
+      let schemaType;
+      if (PROPERTY_TYPE_BY_UNIT.hasOwnProperty(sensor.unit)) {
+        schemaType = PROPERTY_TYPE_BY_UNIT[sensor.unit];
+        if (DEVICE_CAPABILITIES.hasOwnProperty(schemaType)) {
+          const capability = DEVICE_CAPABILITIES[schemaType];
+          if (!deviceCapabilities.includes(capability)) {
+            deviceCapabilities.push(capability);
+          }
+        }
+      }
 
       const property = new Property(this, id, {
+        '@type': schemaType,
         type: 'number',
         title: sensor.title,
+        unit,
         readOnly: true
       });
 
       this.properties.set(id, property);
     }
+
+    this.name = senseBox.name;
+    this['@type'] = deviceCapabilities;
   }
 
   public startPolling(seconds: number) {
@@ -81,9 +130,9 @@ class OpenSenseBox extends Device {
   }
 }
 
-export class GoogleHomeAdapter extends Adapter {
+export class OpenSenseMapAdapter extends Adapter {
   constructor(addonManager: any, private manifest: any) {
-    super(addonManager, GoogleHomeAdapter.name, manifest.name);
+    super(addonManager, OpenSenseMapAdapter.name, manifest.name);
     addonManager.addAdapter(this);
     this.createDevices();
   }


### PR DESCRIPTION
Lots of small little improvements:

- Link to opensensemap web UI as alternate
- Fix adapter name
- Expose sensor units on properties
- Infer schema capabilities from some units
- Set the sense box's human readable name as its name